### PR TITLE
Update class-bbpress-report-content.php

### DIFF
--- a/classes/class-bbpress-report-content.php
+++ b/classes/class-bbpress-report-content.php
@@ -274,7 +274,8 @@ class bbp_ReportContent {
 	public function add_topic_admin_links( $links, $topic_id ) {
 
 		// Only display for logged in users
-		if ( ! is_user_logged_in() )
+		// Do not show "Report" on posts written by users that can moderate (people should not report such users)
+		if ( ! is_user_logged_in() || ( user_can( get_post_field( 'post_author', $topic_id ), 'moderate' ) ) ;)
 			return $links;
 
 		$args = array();


### PR DESCRIPTION
Do not show "Report" on posts written by users that can moderate (people should not report such users). Users that are trusted enough will probably not write something that must be reported. Plus, such trusted users should not have their posts "reported" by people that may be abusing the "report" link.
